### PR TITLE
add support for `zwlr_layer_shell_v1` and `ext_image_copy_capture_v1`

### DIFF
--- a/12to11.c
+++ b/12to11.c
@@ -257,6 +257,8 @@ XLMain (int argc, char **argv)
   XLInitXdgActivation ();
   XLInitTearingControl ();
   XLInitCursorShape ();
+  XLInitLayerShell ();
+  XLInitImageCopyCapture ();
   XLInitTest ();
 
   /* This has to come after the rest of the initialization.  */

--- a/12to11.man
+++ b/12to11.man
@@ -273,6 +273,9 @@ zwp_relative_pointer_manager	1
 zwp_idle_inhibit_manager_v1	1
 xdg_activation_v1	1
 wp_tearing_control_manager_v1	1
+zwlr_layer_shell_v1	4
+ext_image_copy_capture_manager_v1	1
+ext_output_image_capture_source_manager_v1	1
 .TE
 .PP
 When the protocol translator is built with EGL support, the following
@@ -319,6 +322,16 @@ Using this protocol translator under a window manager that does not at
 least support the
 .B _NET_WM_SYNC_REQUEST
 window manager protocol will result in Wayland programs running badly.
+.PP
+Screen capture (via
+.B ext_image_copy_capture_manager_v1
+) reads pixels back from the X root window.  When a compositing manager
+composites into the Composite overlay window rather than the root
+window, the captured image may be incomplete or stale.  Cursor capture
+and the
+.B paint_cursors
+option are not implemented; layer surface popups are not positioned
+relative to their parent layer surface.
 .PP
 .SH "SEE ALSO"
 X(7), Xorg(1)

--- a/Imakefile
+++ b/Imakefile
@@ -18,8 +18,8 @@ MakeSubdirs($(SUBDIRS))
 DependSubdirs($(SUBDIRS))
 #endif
 
-             SRCS = 12to11.c run.c alloc.c fns.c output.c compositor.c surface.c region.c shm.c atoms.c subcompositor.c positioner.c xdg_wm.c xdg_surface.c xdg_toplevel.c frame_clock.c xerror.c ewmh.c timer.c subsurface.c seat.c data_device.c xdg_popup.c dmabuf.c buffer.c select.c xdata.c xsettings.c dnd.c icon_surface.c primary_selection.c renderer.c picture_renderer.c explicit_synchronization.c transform.c wp_viewporter.c decoration.c text_input.c single_pixel_buffer.c drm_lease.c pointer_constraints.c time.c relative_pointer.c keyboard_shortcuts_inhibit.c idle_inhibit.c process.c fence_ring.c pointer_gestures.c test.c buffer_release.c xdg_activation.c tearing_control.c sync_source.c cursor_shape.c
-             OBJS = 12to11.o run.o alloc.o fns.o output.o compositor.o surface.o region.o shm.o atoms.o subcompositor.o positioner.o xdg_wm.o xdg_surface.o xdg_toplevel.o frame_clock.o xerror.o ewmh.o timer.o subsurface.o seat.o data_device.o xdg_popup.o dmabuf.o buffer.o select.o xdata.o xsettings.o dnd.o icon_surface.o primary_selection.o renderer.o picture_renderer.o explicit_synchronization.o transform.o wp_viewporter.o decoration.o text_input.o single_pixel_buffer.o drm_lease.o pointer_constraints.o time.o relative_pointer.o keyboard_shortcuts_inhibit.o idle_inhibit.o process.o fence_ring.o pointer_gestures.o test.o buffer_release.o xdg_activation.o tearing_control.o sync_source.o cursor_shape.o
+             SRCS = 12to11.c run.c alloc.c fns.c output.c compositor.c surface.c region.c shm.c atoms.c subcompositor.c positioner.c xdg_wm.c xdg_surface.c xdg_toplevel.c frame_clock.c xerror.c ewmh.c timer.c subsurface.c seat.c data_device.c xdg_popup.c dmabuf.c buffer.c select.c xdata.c xsettings.c dnd.c icon_surface.c primary_selection.c renderer.c picture_renderer.c explicit_synchronization.c transform.c wp_viewporter.c decoration.c text_input.c single_pixel_buffer.c drm_lease.c pointer_constraints.c time.c relative_pointer.c keyboard_shortcuts_inhibit.c idle_inhibit.c process.c fence_ring.c pointer_gestures.c test.c buffer_release.c xdg_activation.c tearing_control.c sync_source.c cursor_shape.c layer_shell.c image_copy_capture.c
+             OBJS = 12to11.o run.o alloc.o fns.o output.o compositor.o surface.o region.o shm.o atoms.o subcompositor.o positioner.o xdg_wm.o xdg_surface.o xdg_toplevel.o frame_clock.o xerror.o ewmh.o timer.o subsurface.o seat.o data_device.o xdg_popup.o dmabuf.o buffer.o select.o xdata.o xsettings.o dnd.o icon_surface.o primary_selection.o renderer.o picture_renderer.o explicit_synchronization.o transform.o wp_viewporter.o decoration.o text_input.o single_pixel_buffer.o drm_lease.o pointer_constraints.o time.o relative_pointer.o keyboard_shortcuts_inhibit.o idle_inhibit.o process.o fence_ring.o pointer_gestures.o test.o buffer_release.o xdg_activation.o tearing_control.o sync_source.o cursor_shape.o layer_shell.o image_copy_capture.o
        GENHEADERS = transfer_atoms.h drm_modifiers.h
            HEADER = $(GENHEADERS) compositor.h
 
@@ -108,6 +108,9 @@ ScannerTarget(12to11-test)
 ScannerTarget(xdg-activation-v1)
 ScannerTarget(tearing-control-v1)
 ScannerTarget(cursor-shape-v1)
+ScannerTarget(wlr-layer-shell-unstable-v1)
+ScannerTarget(ext-image-capture-source-v1)
+ScannerTarget(ext-image-copy-capture-v1)
 
 /* Make seat.o depend on test_seat.c, as it includes that.  Both files
    are rather special.  */

--- a/README
+++ b/README
@@ -70,6 +70,9 @@ complete degree:
   'zwp_idle_inhibit_manager_v1',                version:  1
   'xdg_activation_v1',                          version:  1
   'wp_tearing_control_manager_v1',		version:  1
+  'zwlr_layer_shell_v1',                        version:  4
+  'ext_image_copy_capture_manager_v1',          version:  1
+  'ext_output_image_capture_source_manager_v1', version:  1
 
 When built with EGL, the following Wayland protocol is also supported:
 

--- a/atoms.c
+++ b/atoms.c
@@ -113,6 +113,15 @@ static const char *names[] =
     "_NET_WM_PING",
     "libinput Scrolling Pixel Distance",
     "_NET_ACTIVE_WINDOW",
+    "_NET_WM_WINDOW_TYPE_DESKTOP",
+    "_NET_WM_WINDOW_TYPE_DOCK",
+    "_NET_WM_WINDOW_TYPE_NOTIFICATION",
+    "_NET_WM_WINDOW_TYPE_NORMAL",
+    "_NET_WM_STATE_ABOVE",
+    "_NET_WM_STATE_BELOW",
+    "_NET_WM_STATE_STICKY",
+    "_NET_WM_STATE_SKIP_TASKBAR",
+    "_NET_WM_STATE_SKIP_PAGER",
 
     /* These are automatically generated from mime.txt.  */
     DirectTransferAtomNames
@@ -135,6 +144,10 @@ Atom _NET_WM_OPAQUE_REGION, _XL_BUFFER_RELEASE, _NET_WM_SYNC_REQUEST_COUNTER,
   XdndEnter, XdndPosition, XdndStatus, XdndLeave, XdndDrop, XdndFinished,
   _NET_WM_FRAME_TIMINGS, _NET_WM_BYPASS_COMPOSITOR, WM_STATE,
   _NET_WM_WINDOW_TYPE, _NET_WM_WINDOW_TYPE_MENU, _NET_WM_WINDOW_TYPE_DND,
+  _NET_WM_WINDOW_TYPE_DESKTOP, _NET_WM_WINDOW_TYPE_DOCK,
+  _NET_WM_WINDOW_TYPE_NOTIFICATION, _NET_WM_WINDOW_TYPE_NORMAL,
+  _NET_WM_STATE_ABOVE, _NET_WM_STATE_BELOW, _NET_WM_STATE_STICKY,
+  _NET_WM_STATE_SKIP_TASKBAR, _NET_WM_STATE_SKIP_PAGER,
   CONNECTOR_ID, _NET_WM_PID, _NET_WM_PING, libinput_Scrolling_Pixel_Distance,
   _NET_ACTIVE_WINDOW;
 
@@ -295,9 +308,18 @@ XLInitAtoms (void)
   _NET_WM_PING = atoms[63];
   libinput_Scrolling_Pixel_Distance = atoms[64];
   _NET_ACTIVE_WINDOW = atoms[65];
+  _NET_WM_WINDOW_TYPE_DESKTOP = atoms[66];
+  _NET_WM_WINDOW_TYPE_DOCK = atoms[67];
+  _NET_WM_WINDOW_TYPE_NOTIFICATION = atoms[68];
+  _NET_WM_WINDOW_TYPE_NORMAL = atoms[69];
+  _NET_WM_STATE_ABOVE = atoms[70];
+  _NET_WM_STATE_BELOW = atoms[71];
+  _NET_WM_STATE_STICKY = atoms[72];
+  _NET_WM_STATE_SKIP_TASKBAR = atoms[73];
+  _NET_WM_STATE_SKIP_PAGER = atoms[74];
 
   /* This is automatically generated.  */
-  DirectTransferAtomInit (atoms, 66);
+  DirectTransferAtomInit (atoms, 75);
 
   /* Now, initialize quarks.  */
   resource_quark = XrmPermStringToQuark (compositor.resource_name);

--- a/compositor.h
+++ b/compositor.h
@@ -783,6 +783,8 @@ extern void ExtBufferDestroy (ExtBuffer *);
 extern int render_first_error;
 
 extern void XLInitShm (void);
+extern Bool XLShmBufferDescribe (ExtBuffer *, int *, size_t *, uint32_t *,
+				 int *, int *, unsigned int *, unsigned int *);
 
 /* Defined in subcompositor.c.  */
 
@@ -923,6 +925,7 @@ enum _RoleType
     CursorType,
     DndIconType,
     TestSurfaceType,
+    LayerType,
   };
 
 #define RotatesDimensions(transform)		\
@@ -1261,6 +1264,8 @@ extern void XLInitRROutputs (void);
 extern Bool XLHandleOneXEventForOutputs (XEvent *);
 extern void XLOutputGetMinRefresh (struct timespec *);
 extern Bool XLGetOutputRectAt (int, int, int *, int *, int *, int *);
+extern Bool XLGetOutputRectFromResource (struct wl_resource *, int *,
+					 int *, int *, int *);
 extern void *XLAddScaleChangeCallback (void *, void (*) (void *, int));
 extern void XLRemoveScaleChangeCallback (void *);
 extern void XLClearOutputs (Surface *);
@@ -1286,6 +1291,10 @@ extern Atom _NET_WM_OPAQUE_REGION, _XL_BUFFER_RELEASE,
   XdndProxy, XdndEnter, XdndPosition, XdndStatus, XdndLeave, XdndDrop,
   XdndFinished, _NET_WM_FRAME_TIMINGS, _NET_WM_BYPASS_COMPOSITOR, WM_STATE,
   _NET_WM_WINDOW_TYPE, _NET_WM_WINDOW_TYPE_MENU, _NET_WM_WINDOW_TYPE_DND,
+  _NET_WM_WINDOW_TYPE_DESKTOP, _NET_WM_WINDOW_TYPE_DOCK,
+  _NET_WM_WINDOW_TYPE_NOTIFICATION, _NET_WM_WINDOW_TYPE_NORMAL,
+  _NET_WM_STATE_ABOVE, _NET_WM_STATE_BELOW, _NET_WM_STATE_STICKY,
+  _NET_WM_STATE_SKIP_TASKBAR, _NET_WM_STATE_SKIP_PAGER,
   CONNECTOR_ID, _NET_WM_PID, _NET_WM_PING, libinput_Scrolling_Pixel_Distance,
   _NET_ACTIVE_WINDOW;
 
@@ -1937,6 +1946,15 @@ extern void XLInitTearingControl (void);
 /* Defined in cursor_shape.c.  */
 
 extern void XLInitCursorShape (void);
+
+/* Defined in layer_shell.c.  */
+
+extern void XLInitLayerShell (void);
+extern Bool XLHandleOneXEventForLayerShell (XEvent *);
+
+/* Defined in image_copy_capture.c.  */
+
+extern void XLInitImageCopyCapture (void);
 
 /* Defined in sync_source.h.  */
 

--- a/ext-image-capture-source-v1.xml
+++ b/ext-image-capture-source-v1.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_image_capture_source_v1">
+  <copyright>
+    Copyright © 2022 Andri Yngvason
+    Copyright © 2024 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="opaque image capture source objects">
+    This protocol serves as an intermediary between capturing protocols and
+    potential image capture sources such as outputs and toplevels.
+
+    This protocol may be extended to support more image capture sources in the
+    future, thereby adding those image capture sources to other protocols that
+    use the image capture source object without having to modify those
+    protocols.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_image_capture_source_v1" version="1" frozen="true">
+    <description summary="opaque image capture source object">
+      The image capture source object is an opaque descriptor for a capturable
+      resource.  This resource may be any sort of entity from which an image
+      may be derived.
+
+      Note, because ext_image_capture_source_v1 objects are created from multiple
+      independent factory interfaces, the ext_image_capture_source_v1 interface is
+      frozen at version 1.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the image capture source. This request may be sent at any time
+        by the client.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_output_image_capture_source_manager_v1" version="1">
+    <description summary="image capture source manager for outputs">
+      A manager for creating image capture source objects for wl_output objects.
+    </description>
+
+    <request name="create_source">
+      <description summary="create source object for output">
+        Creates a source object for an output. Images captured from this source
+        will show the same content as the output. Some elements may be omitted,
+        such as cursors and overlays that have been marked as transparent to
+        capturing.
+      </description>
+      <arg name="source" type="new_id" interface="ext_image_capture_source_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the manager. This request may be sent at any time by the
+        client and objects created by the manager will remain valid after its
+        destruction.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/ext-image-copy-capture-v1.xml
+++ b/ext-image-copy-capture-v1.xml
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_image_copy_capture_v1">
+  <copyright>
+    Copyright © 2021-2023 Andri Yngvason
+    Copyright © 2024 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="image capturing into client buffers">
+    This protocol allows clients to ask the compositor to capture image sources
+    such as outputs and toplevels into user submitted buffers.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_image_copy_capture_manager_v1" version="1">
+    <description summary="manager to inform clients and begin capturing">
+      This object is a manager which offers requests to start capturing from a
+      source.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_option" value="1" summary="invalid option flag"/>
+    </enum>
+
+    <enum name="options" bitfield="true">
+      <entry name="paint_cursors" value="1" summary="paint cursors onto captured frames"/>
+    </enum>
+
+    <request name="create_session">
+      <description summary="capture an image capture source">
+        Create a capturing session for an image capture source.
+
+        If the paint_cursors option is set, cursors shall be composited onto
+        the captured frame. The cursor must not be composited onto the frame
+        if this flag is not set.
+
+        If the options bitfield is invalid, the invalid_option protocol error
+        is sent.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_session_v1"/>
+      <arg name="source" type="object" interface="ext_image_capture_source_v1"/>
+      <arg name="options" type="uint" enum="options"/>
+    </request>
+
+    <request name="create_pointer_cursor_session">
+      <description summary="capture the pointer cursor of an image capture source">
+        Create a cursor capturing session for the pointer of an image capture
+        source.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_cursor_session_v1"/>
+      <arg name="source" type="object" interface="ext_image_capture_source_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object.
+
+        Other objects created via this interface are unaffected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_image_copy_capture_session_v1" version="1">
+    <description summary="image copy capture session">
+      This object represents an active image copy capture session.
+
+      After a capture session is created, buffer constraint events will be
+      emitted from the compositor to tell the client which buffer types and
+      formats are supported for reading from the session. The compositor may
+      re-send buffer constraint events whenever they change.
+
+      To advertise buffer constraints, the compositor must send in no
+      particular order: zero or more shm_format and dmabuf_format events, zero
+      or one dmabuf_device event, and exactly one buffer_size event. Then the
+      compositor must send a done event.
+
+      When the client has received all the buffer constraints, it can create a
+      buffer accordingly, attach it to the capture session using the
+      attach_buffer request, set the buffer damage using the damage_buffer
+      request and then send the capture request.
+    </description>
+
+    <enum name="error">
+      <entry name="duplicate_frame" value="1"
+        summary="create_frame sent before destroying previous frame"/>
+    </enum>
+
+    <event name="buffer_size">
+      <description summary="image capture source dimensions">
+        Provides the dimensions of the source image in buffer pixel coordinates.
+
+        The client must attach buffers that match this size.
+      </description>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+    </event>
+
+    <event name="shm_format">
+      <description summary="shm buffer format">
+        Provides the format that must be used for shared-memory buffers.
+
+        This event may be emitted multiple times, in which case the client may
+        choose any given format.
+      </description>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="shm format"/>
+    </event>
+
+    <event name="dmabuf_device">
+      <description summary="dma-buf device">
+        This event advertises the device buffers must be allocated on for
+        dma-buf buffers.
+
+        In general the device is a DRM node. The DRM node type (primary vs.
+        render) is unspecified. Clients must not rely on the compositor sending
+        a particular node type. Clients cannot check two devices for equality
+        by comparing the dev_t value.
+      </description>
+      <arg name="device" type="array" summary="device dev_t value"/>
+    </event>
+
+    <event name="dmabuf_format">
+      <description summary="dma-buf format">
+        Provides the format that must be used for dma-buf buffers.
+
+        The client may choose any of the modifiers advertised in the array of
+        64-bit unsigned integers.
+
+        This event may be emitted multiple times, in which case the client may
+        choose any given format.
+      </description>
+      <arg name="format" type="uint" summary="drm format code"/>
+      <arg name="modifiers" type="array" summary="drm format modifiers"/>
+    </event>
+
+    <event name="done">
+      <description summary="all constraints have been sent">
+        This event is sent once when all buffer constraint events have been
+        sent.
+
+        The compositor must always end a batch of buffer constraint events with
+        this event, regardless of whether it sends the initial constraints or
+        an update.
+      </description>
+    </event>
+
+    <event name="stopped">
+      <description summary="session is no longer available">
+        This event indicates that the capture session has stopped and is no
+        longer available. This can happen in a number of cases, e.g. when the
+        underlying source is destroyed, if the user decides to end the image
+        capture, or if an unrecoverable runtime error has occurred.
+
+        The client should destroy the session after receiving this event.
+      </description>
+    </event>
+
+    <request name="create_frame">
+      <description summary="create a frame">
+        Create a capture frame for this session.
+
+        At most one frame object can exist for a given session at any time. If
+        a client sends a create_frame request before a previous frame object
+        has been destroyed, the duplicate_frame protocol error is raised.
+      </description>
+      <arg name="frame" type="new_id" interface="ext_image_copy_capture_frame_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the session. This request can be sent at any time by the
+        client.
+
+        This request doesn't affect ext_image_copy_capture_frame_v1 objects created by
+        this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_image_copy_capture_frame_v1" version="1">
+    <description summary="image capture frame">
+      This object represents an image capture frame.
+
+      The client should attach a buffer, damage the buffer, and then send a
+      capture request.
+
+      If the capture is successful, the compositor must send the frame metadata
+      (transform, damage, presentation_time in any order) followed by the ready
+      event.
+
+      If the capture fails, the compositor must send the failed event.
+    </description>
+
+    <enum name="error">
+      <entry name="no_buffer" value="1" summary="capture sent without attach_buffer"/>
+      <entry name="invalid_buffer_damage" value="2" summary="invalid buffer damage"/>
+      <entry name="already_captured" value="3" summary="capture request has been sent"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this object">
+        Destroys the frame. This request can be sent at any time by the
+        client.
+      </description>
+    </request>
+
+    <request name="attach_buffer">
+      <description summary="attach buffer to session">
+        Attach a buffer to the session.
+
+        The wl_buffer.release request is unused.
+
+        The new buffer replaces any previously attached buffer.
+
+        This request must not be sent after capture, or else the
+        already_captured protocol error is raised.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+
+    <request name="damage_buffer">
+      <description summary="damage buffer">
+        Apply damage to the buffer which is to be captured next. This request
+        may be sent multiple times to describe a region.
+
+        The client indicates the accumulated damage since this wl_buffer was
+        last captured. During capture, the compositor will update the buffer
+        with at least the union of the region passed by the client and the
+        region advertised by ext_image_copy_capture_frame_v1.damage.
+
+        When a wl_buffer is captured for the first time, or when the client
+        doesn't track damage, the client must damage the whole buffer.
+
+        This is for optimisation purposes. The compositor may use this
+        information to reduce copying.
+
+        These coordinates originate from the upper left corner of the buffer.
+
+        If x or y are strictly negative, or if width or height are negative or
+        zero, the invalid_buffer_damage protocol error is raised.
+
+        This request must not be sent after capture, or else the
+        already_captured protocol error is raised.
+      </description>
+      <arg name="x" type="int" summary="region x coordinate"/>
+      <arg name="y" type="int" summary="region y coordinate"/>
+      <arg name="width" type="int" summary="region width"/>
+      <arg name="height" type="int" summary="region height"/>
+    </request>
+
+    <request name="capture">
+      <description summary="capture a frame">
+        Capture a frame.
+
+        Unless this is the first successful captured frame performed in this
+        session, the compositor may wait an indefinite amount of time for the
+        source content to change before performing the copy.
+
+        This request may only be sent once, or else the already_captured
+        protocol error is raised. A buffer must be attached before this request
+        is sent, or else the no_buffer protocol error is raised.
+      </description>
+    </request>
+
+    <event name="transform">
+      <description summary="buffer transform">
+        This event is sent before the ready event and holds the transform that
+        the compositor has applied to the buffer contents.
+      </description>
+      <arg name="transform" type="uint" enum="wl_output.transform"/>
+    </event>
+
+    <event name="damage">
+      <description summary="buffer damaged region">
+        This event is sent before the ready event. It may be generated multiple
+        times to describe a region.
+
+        The first captured frame in a session will always carry full damage.
+        Subsequent frames' damaged regions describe which parts of the buffer
+        have changed since the last ready event.
+
+        These coordinates originate in the upper left corner of the buffer.
+      </description>
+      <arg name="x" type="int" summary="damage x coordinate"/>
+      <arg name="y" type="int" summary="damage y coordinate"/>
+      <arg name="width" type="int" summary="damage width"/>
+      <arg name="height" type="int" summary="damage height"/>
+    </event>
+
+    <event name="presentation_time">
+      <description summary="presentation time of the frame">
+        This event indicates the time at which the frame is presented to the
+        output in system monotonic time. This event is sent before the ready
+        event.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999].
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="ready">
+      <description summary="frame is available for reading">
+        Called as soon as the frame is copied, indicating it is available
+        for reading.
+
+        The buffer may be re-used by the client after this event.
+
+        After receiving this event, the client must destroy the object.
+      </description>
+    </event>
+
+    <enum name="failure_reason">
+      <entry name="unknown" value="0">
+        <description summary="unknown runtime error">
+          An unspecified runtime error has occurred. The client may retry.
+        </description>
+      </entry>
+      <entry name="buffer_constraints" value="1">
+        <description summary="buffer constraints mismatch">
+          The buffer submitted by the client doesn't match the latest session
+          constraints. The client should re-allocate its buffers and retry.
+        </description>
+      </entry>
+      <entry name="stopped" value="2">
+        <description summary="session is no longer available">
+          The session has stopped. See ext_image_copy_capture_session_v1.stopped.
+        </description>
+      </entry>
+    </enum>
+
+    <event name="failed">
+      <description summary="capture failed">
+        This event indicates that the attempted frame copy has failed.
+
+        After receiving this event, the client must destroy the object.
+      </description>
+      <arg name="reason" type="uint" enum="failure_reason"/>
+    </event>
+  </interface>
+
+  <interface name="ext_image_copy_capture_cursor_session_v1" version="1">
+    <description summary="cursor capture session">
+      This object represents a cursor capture session. It extends the base
+      capture session with cursor-specific metadata.
+    </description>
+
+    <enum name="error">
+      <entry name="duplicate_session" value="1" summary="get_capture_session sent twice"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the session. This request can be sent at any time by the
+        client.
+
+        This request doesn't affect ext_image_copy_capture_frame_v1 objects created by
+        this object.
+      </description>
+    </request>
+
+    <request name="get_capture_session">
+      <description summary="get image copy capturer session">
+        Gets the image copy capture session for this cursor session.
+
+        The session will produce frames of the cursor image. The compositor may
+        pause the session when the cursor leaves the captured area.
+
+        This request must not be sent more than once, or else the
+        duplicate_session protocol error is raised.
+      </description>
+      <arg name="session" type="new_id" interface="ext_image_copy_capture_session_v1"/>
+    </request>
+
+    <event name="enter">
+      <description summary="cursor entered captured area">
+        Sent when a cursor enters the captured area. It shall be generated
+        before the "position" and "hotspot" events when and only when a cursor
+        enters the area.
+
+        The cursor enters the captured area when the cursor image intersects
+        with the captured area. Note, this is different from e.g.
+        wl_pointer.enter.
+      </description>
+    </event>
+
+    <event name="leave">
+      <description summary="cursor left captured area">
+        Sent when a cursor leaves the captured area. No "position" or "hotspot"
+        event is generated for the cursor until the cursor enters the captured
+        area again.
+      </description>
+    </event>
+
+    <event name="position">
+      <description summary="position changed">
+        Cursors outside the image capture source do not get captured and no
+        event will be generated for them.
+
+        The given position is the position of the cursor's hotspot and it is
+        relative to the main buffer's top left corner in transformed buffer
+        pixel coordinates. The coordinates may be negative or greater than the
+        main buffer size.
+      </description>
+      <arg name="x" type="int" summary="position x coordinates"/>
+      <arg name="y" type="int" summary="position y coordinates"/>
+    </event>
+
+    <event name="hotspot">
+      <description summary="hotspot changed">
+        The hotspot describes the offset between the cursor image and the
+        position of the input device.
+
+        The given coordinates are the hotspot's offset from the origin in
+        buffer coordinates.
+
+        Clients should not apply the hotspot immediately: the hotspot becomes
+        effective when the next ext_image_copy_capture_frame_v1.ready event is received.
+
+        Compositors may delay this event until the client captures a new frame.
+      </description>
+      <arg name="x" type="int" summary="hotspot x coordinates"/>
+      <arg name="y" type="int" summary="hotspot y coordinates"/>
+    </event>
+  </interface>
+</protocol>

--- a/image_copy_capture.c
+++ b/image_copy_capture.c
@@ -1,0 +1,734 @@
+/* Wayland compositor running on top of an X server.
+
+Copyright (C) 2022 to various contributors.
+
+This file is part of 12to11.
+
+12to11 is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+12to11 is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with 12to11.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* ext_image_copy_capture_manager_v1 and ext_image_capture_source_v1
+   implementation.
+
+   This allows Wayland clients (such as screenshot tools) to capture
+   the contents of an output into a client-supplied shared memory
+   buffer.  The pixels are read back from the X server with
+   XGetImage.  */
+
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#include "compositor.h"
+#include "ext-image-capture-source-v1.h"
+#include "ext-image-copy-capture-v1.h"
+
+typedef struct _CaptureSource CaptureSource;
+typedef struct _CaptureSession CaptureSession;
+typedef struct _CaptureFrame CaptureFrame;
+
+struct _CaptureSource
+{
+  /* The resource for this source.  */
+  struct wl_resource *resource;
+
+  /* The output being captured, or NULL.  */
+  struct wl_resource *output_resource;
+};
+
+struct _CaptureSession
+{
+  /* The resource for this session.  */
+  struct wl_resource *resource;
+
+  /* The output being captured.  */
+  struct wl_resource *output_resource;
+
+  /* The capture rectangle in root window coordinates and the buffer
+     dimensions advertised to the client.  */
+  int ox, oy, ow, oh;
+
+  /* Options given at creation.  */
+  uint32_t options;
+
+  /* Whether this is a cursor capture session (unsupported, always
+     stops).  */
+  Bool cursor;
+
+  /* The single live frame, or NULL.  */
+  CaptureFrame *frame;
+};
+
+struct _CaptureFrame
+{
+  /* The resource for this frame.  */
+  struct wl_resource *resource;
+
+  /* The owning session, or NULL if the session was destroyed.  */
+  CaptureSession *session;
+
+  /* The buffer attached by the client.  */
+  struct wl_resource *buffer;
+
+  /* Whether capture has been requested.  */
+  Bool captured;
+};
+
+/* The two globals.  */
+static struct wl_global *source_manager_global;
+static struct wl_global *copy_capture_manager_global;
+
+/* Forward declarations of static functions.  */
+
+static void ComputeRect (struct wl_resource *, int *, int *, int *,
+			 int *);
+static void SendConstraints (CaptureSession *);
+static void FailFrame (CaptureFrame *, uint32_t);
+static void SendPresentationTime (struct wl_resource *);
+
+
+
+/* Geometry helper.  */
+
+static void
+ComputeRect (struct wl_resource *output_resource, int *ox, int *oy,
+	     int *ow, int *oh)
+{
+  if (output_resource
+      && XLGetOutputRectFromResource (output_resource, ox, oy, ow, oh))
+    return;
+
+  /* Fall back to the whole screen.  */
+  *ox = 0;
+  *oy = 0;
+  *ow = DisplayWidth (compositor.display,
+		      DefaultScreen (compositor.display));
+  *oh = DisplayHeight (compositor.display,
+		       DefaultScreen (compositor.display));
+}
+
+static void
+SendConstraints (CaptureSession *session)
+{
+  /* Tell the client the buffer dimensions.  */
+  ext_image_copy_capture_session_v1_send_buffer_size (session->resource,
+						       session->ow,
+						       session->oh);
+
+  /* Advertise the shared memory formats we can produce by direct
+     copy.  The X server provides 32-bit XRGB/ARGB data, little
+     endian.  */
+  ext_image_copy_capture_session_v1_send_shm_format (session->resource,
+						      WL_SHM_FORMAT_XRGB8888);
+  ext_image_copy_capture_session_v1_send_shm_format (session->resource,
+						      WL_SHM_FORMAT_ARGB8888);
+
+  ext_image_copy_capture_session_v1_send_done (session->resource);
+}
+
+static void
+SendPresentationTime (struct wl_resource *resource)
+{
+  struct timespec ts;
+  uint64_t sec;
+
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  sec = (uint64_t) ts.tv_sec;
+
+  ext_image_copy_capture_frame_v1_send_presentation_time
+    (resource,
+     (uint32_t) (sec >> 32),
+     (uint32_t) (sec & 0xffffffffu),
+     (uint32_t) ts.tv_nsec);
+}
+
+static void
+FailFrame (CaptureFrame *frame, uint32_t reason)
+{
+  if (!frame->resource)
+    return;
+
+  ext_image_copy_capture_frame_v1_send_failed (frame->resource, reason);
+}
+
+
+/* Capture frame requests.  */
+
+static void
+FrameDestroy (struct wl_client *client, struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static void
+FrameAttachBuffer (struct wl_client *client, struct wl_resource *resource,
+		   struct wl_resource *buffer)
+{
+  CaptureFrame *frame;
+
+  frame = wl_resource_get_user_data (resource);
+
+  if (frame->captured)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_ALREADY_CAPTURED,
+			      "attach_buffer sent after capture");
+      return;
+    }
+
+  frame->buffer = buffer;
+}
+
+static void
+FrameDamageBuffer (struct wl_client *client, struct wl_resource *resource,
+		   int32_t x, int32_t y, int32_t width, int32_t height)
+{
+  CaptureFrame *frame;
+
+  frame = wl_resource_get_user_data (resource);
+
+  if (frame->captured)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_ALREADY_CAPTURED,
+			      "damage_buffer sent after capture");
+      return;
+    }
+
+  /* Validate the damage rectangle.  The protocol requires this to be a
+     proper region; the actual damage is ignored here, since the whole
+     buffer is always copied.  */
+  if (x < 0 || y < 0 || width <= 0 || height <= 0)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_INVALID_BUFFER_DAMAGE,
+			      "invalid buffer damage");
+      return;
+    }
+}
+
+static void
+FrameCapture (struct wl_client *client, struct wl_resource *resource)
+{
+  CaptureFrame *frame;
+  CaptureSession *session;
+  ExtBuffer *eb;
+  int fd, offset, stride, y;
+  unsigned int bw, bh;
+  size_t pool_size;
+  uint32_t format;
+  void *data;
+  XImage *image;
+  uint8_t *dst, *src;
+
+  frame = wl_resource_get_user_data (resource);
+
+  if (frame->captured)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_ALREADY_CAPTURED,
+			      "capture sent more than once");
+      return;
+    }
+
+  if (!frame->buffer)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_FRAME_V1_ERROR_NO_BUFFER,
+			      "capture sent without attach_buffer");
+      return;
+    }
+
+  frame->captured = True;
+
+  session = frame->session;
+
+  if (!session || session->cursor)
+    {
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_STOPPED);
+      return;
+    }
+
+  /* Describe the attached shared memory buffer.  */
+  eb = wl_resource_get_user_data (frame->buffer);
+
+  if (!XLShmBufferDescribe (eb, &fd, &pool_size, &format, &offset,
+			    &stride, &bw, &bh))
+    {
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
+      return;
+    }
+
+  /* The buffer must match the advertised dimensions.  */
+  if ((int) bw != session->ow || (int) bh != session->oh)
+    {
+      close (fd);
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
+      return;
+    }
+
+  /* Only 32-bit XRGB/ARGB can be produced by direct copy.  */
+  if (format != WL_SHM_FORMAT_XRGB8888
+      && format != WL_SHM_FORMAT_ARGB8888)
+    {
+      close (fd);
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_BUFFER_CONSTRAINTS);
+      return;
+    }
+
+  /* Map the pool writable.  */
+  data = mmap (NULL, pool_size, PROT_READ | PROT_WRITE, MAP_SHARED,
+	       fd, 0);
+  close (fd);
+
+  if (data == MAP_FAILED)
+    {
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+      return;
+    }
+
+  /* Read back the output rectangle from the root window.  */
+  image = XGetImage (compositor.display,
+		     DefaultRootWindow (compositor.display),
+		     session->ox, session->oy,
+		     session->ow, session->oh,
+		     AllPlanes, ZPixmap);
+
+  if (!image)
+    {
+      munmap (data, pool_size);
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+      return;
+    }
+
+  /* The X server is expected to provide 32 bits per pixel, little
+     endian, matching the shared memory formats above.  */
+  if (image->bits_per_pixel != 32
+      || image->byte_order != LSBFirst)
+    {
+      XDestroyImage (image);
+      munmap (data, pool_size);
+      FailFrame (frame,
+		 EXT_IMAGE_COPY_CAPTURE_FRAME_V1_FAILURE_REASON_UNKNOWN);
+      return;
+    }
+
+  /* Copy each scanline into the client buffer, accounting for
+     differing strides.  */
+  dst = (uint8_t *) data + offset;
+  src = (uint8_t *) image->data;
+
+  for (y = 0; y < session->oh; ++y)
+    memcpy (dst + y * stride, src + y * image->bytes_per_line,
+	    session->ow * 4);
+
+  msync (data, pool_size, MS_SYNC);
+  munmap (data, pool_size);
+  XDestroyImage (image);
+
+  /* Emit the frame metadata followed by ready.  */
+  ext_image_copy_capture_frame_v1_send_transform
+    (resource, WL_OUTPUT_TRANSFORM_NORMAL);
+  ext_image_copy_capture_frame_v1_send_damage (resource, 0, 0,
+					       session->ow, session->oh);
+  SendPresentationTime (resource);
+  ext_image_copy_capture_frame_v1_send_ready (resource);
+}
+
+static const struct ext_image_copy_capture_frame_v1_interface frame_impl =
+  {
+    .destroy = FrameDestroy,
+    .attach_buffer = FrameAttachBuffer,
+    .damage_buffer = FrameDamageBuffer,
+    .capture = FrameCapture,
+  };
+
+static void
+HandleFrameResourceDestroy (struct wl_resource *resource)
+{
+  CaptureFrame *frame;
+
+  frame = wl_resource_get_user_data (resource);
+
+  /* Detach the frame from its session.  */
+  if (frame->session)
+    {
+      XLAssert (frame->session->frame == frame);
+      frame->session->frame = NULL;
+    }
+
+  frame->resource = NULL;
+  XLFree (frame);
+}
+
+
+/* Capture session requests.  */
+
+static void
+SessionDestroy (struct wl_client *client, struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static void
+SessionCreateFrame (struct wl_client *client, struct wl_resource *resource,
+		    uint32_t id)
+{
+  CaptureSession *session;
+  CaptureFrame *frame;
+
+  session = wl_resource_get_user_data (resource);
+
+  if (session->frame)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_SESSION_V1_ERROR_DUPLICATE_FRAME,
+			      "create_frame sent before destroying the"
+			      " previous frame");
+      return;
+    }
+
+  frame = XLSafeMalloc (sizeof *frame);
+
+  if (!frame)
+    {
+      wl_resource_post_no_memory (resource);
+      return;
+    }
+
+  memset (frame, 0, sizeof *frame);
+
+  frame->resource
+    = wl_resource_create (client,
+			  &ext_image_copy_capture_frame_v1_interface,
+			  wl_resource_get_version (resource), id);
+
+  if (!frame->resource)
+    {
+      wl_resource_post_no_memory (resource);
+      XLFree (frame);
+      return;
+    }
+
+  frame->session = session;
+  session->frame = frame;
+
+  wl_resource_set_implementation (frame->resource, &frame_impl,
+				  frame, HandleFrameResourceDestroy);
+}
+
+static const struct ext_image_copy_capture_session_v1_interface
+  session_impl =
+  {
+    .create_frame = SessionCreateFrame,
+    .destroy = SessionDestroy,
+  };
+
+static void
+HandleSessionResourceDestroy (struct wl_resource *resource)
+{
+  CaptureSession *session;
+
+  session = wl_resource_get_user_data (resource);
+
+  /* The session can be destroyed before its frame.  Detach any live
+     frame so it cannot reference this session any more.  */
+  if (session->frame)
+    session->frame->session = NULL;
+
+  session->resource = NULL;
+  XLFree (session);
+}
+
+static CaptureSession *
+MakeSession (struct wl_client *client, struct wl_resource *manager,
+	     uint32_t id, struct wl_resource *output_resource,
+	     uint32_t options, Bool cursor)
+{
+  CaptureSession *session;
+
+  session = XLSafeMalloc (sizeof *session);
+
+  if (!session)
+    {
+      wl_resource_post_no_memory (manager);
+      return NULL;
+    }
+
+  memset (session, 0, sizeof *session);
+
+  session->resource
+    = wl_resource_create (client,
+			  &ext_image_copy_capture_session_v1_interface,
+			  wl_resource_get_version (manager), id);
+
+  if (!session->resource)
+    {
+      wl_resource_post_no_memory (manager);
+      XLFree (session);
+      return NULL;
+    }
+
+  session->output_resource = output_resource;
+  session->options = options;
+  session->cursor = cursor;
+
+  ComputeRect (output_resource, &session->ox, &session->oy,
+	       &session->ow, &session->oh);
+
+  wl_resource_set_implementation (session->resource, &session_impl,
+				  session, HandleSessionResourceDestroy);
+
+  return session;
+}
+
+
+/* Cursor capture session requests.  */
+
+static void
+CursorSessionDestroy (struct wl_client *client,
+		      struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static void
+CursorSessionGetCaptureSession (struct wl_client *client,
+				struct wl_resource *resource, uint32_t id)
+{
+  CaptureSession *session;
+
+  /* Cursor capture is not implemented.  Create a session bound to no
+     output and immediately stop it, signaling unavailability.  */
+  session = MakeSession (client, resource, id, NULL, 0, True);
+
+  if (!session)
+    return;
+
+  ext_image_copy_capture_session_v1_send_stopped (session->resource);
+}
+
+static const struct ext_image_copy_capture_cursor_session_v1_interface
+  cursor_session_impl =
+  {
+    .destroy = CursorSessionDestroy,
+    .get_capture_session = CursorSessionGetCaptureSession,
+  };
+
+
+/* Copy capture manager requests.  */
+
+static void
+ManagerDestroy (struct wl_client *client, struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static void
+ManagerCreateSession (struct wl_client *client,
+		      struct wl_resource *resource, uint32_t id,
+		      struct wl_resource *source_resource, uint32_t options)
+{
+  CaptureSource *source;
+  CaptureSession *session;
+
+  /* Validate options.  Only paint_cursors is defined.  */
+  if (options & ~EXT_IMAGE_COPY_CAPTURE_MANAGER_V1_OPTIONS_PAINT_CURSORS)
+    {
+      wl_resource_post_error (resource,
+			      EXT_IMAGE_COPY_CAPTURE_MANAGER_V1_ERROR_INVALID_OPTION,
+			      "invalid option flag");
+      return;
+    }
+
+  source = wl_resource_get_user_data (source_resource);
+
+  session = MakeSession (client, resource, id,
+			 source ? source->output_resource : NULL,
+			 options, False);
+
+  if (!session)
+    return;
+
+  /* Send the buffer constraints.  */
+  SendConstraints (session);
+}
+
+static void
+ManagerCreatePointerCursorSession (struct wl_client *client,
+				   struct wl_resource *resource,
+				   uint32_t id,
+				   struct wl_resource *source_resource,
+				   struct wl_resource *pointer)
+{
+  struct wl_resource *cursor_resource;
+
+  cursor_resource
+    = wl_resource_create (client,
+			  &ext_image_copy_capture_cursor_session_v1_interface,
+			  wl_resource_get_version (resource), id);
+
+  if (!cursor_resource)
+    {
+      wl_resource_post_no_memory (resource);
+      return;
+    }
+
+  wl_resource_set_implementation (cursor_resource, &cursor_session_impl,
+				  NULL, NULL);
+}
+
+static const struct ext_image_copy_capture_manager_v1_interface
+  manager_impl =
+  {
+    .create_session = ManagerCreateSession,
+    .create_pointer_cursor_session = ManagerCreatePointerCursorSession,
+    .destroy = ManagerDestroy,
+  };
+
+static void
+HandleManagerBind (struct wl_client *client, void *data,
+		   uint32_t version, uint32_t id)
+{
+  struct wl_resource *resource;
+
+  resource = wl_resource_create (client,
+				 &ext_image_copy_capture_manager_v1_interface,
+				 version, id);
+
+  if (!resource)
+    {
+      wl_client_post_no_memory (client);
+      return;
+    }
+
+  wl_resource_set_implementation (resource, &manager_impl, NULL, NULL);
+}
+
+
+/* Capture source manager requests.  */
+
+static void
+SourceDestroy (struct wl_client *client, struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static const struct ext_image_capture_source_v1_interface source_impl =
+  {
+    .destroy = SourceDestroy,
+  };
+
+static void
+HandleSourceResourceDestroy (struct wl_resource *resource)
+{
+  CaptureSource *source;
+
+  source = wl_resource_get_user_data (resource);
+  source->resource = NULL;
+  XLFree (source);
+}
+
+static void
+SourceManagerCreateSource (struct wl_client *client,
+			   struct wl_resource *resource, uint32_t id,
+			   struct wl_resource *output)
+{
+  CaptureSource *source;
+
+  source = XLSafeMalloc (sizeof *source);
+
+  if (!source)
+    {
+      wl_resource_post_no_memory (resource);
+      return;
+    }
+
+  memset (source, 0, sizeof *source);
+
+  source->resource
+    = wl_resource_create (client,
+			  &ext_image_capture_source_v1_interface,
+			  wl_resource_get_version (resource), id);
+
+  if (!source->resource)
+    {
+      wl_resource_post_no_memory (resource);
+      XLFree (source);
+      return;
+    }
+
+  source->output_resource = output;
+
+  wl_resource_set_implementation (source->resource, &source_impl,
+				  source, HandleSourceResourceDestroy);
+}
+
+static void
+SourceManagerDestroy (struct wl_client *client,
+		      struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static const struct
+  ext_output_image_capture_source_manager_v1_interface
+  source_manager_impl =
+  {
+    .create_source = SourceManagerCreateSource,
+    .destroy = SourceManagerDestroy,
+  };
+
+static void
+HandleSourceManagerBind (struct wl_client *client, void *data,
+			 uint32_t version, uint32_t id)
+{
+  struct wl_resource *resource;
+
+  resource = wl_resource_create
+    (client, &ext_output_image_capture_source_manager_v1_interface,
+     version, id);
+
+  if (!resource)
+    {
+      wl_client_post_no_memory (client);
+      return;
+    }
+
+  wl_resource_set_implementation (resource, &source_manager_impl,
+				  NULL, NULL);
+}
+
+void
+XLInitImageCopyCapture (void)
+{
+  source_manager_global
+    = wl_global_create (compositor.wl_display,
+			&ext_output_image_capture_source_manager_v1_interface,
+			1, NULL, HandleSourceManagerBind);
+
+  copy_capture_manager_global
+    = wl_global_create (compositor.wl_display,
+			&ext_image_copy_capture_manager_v1_interface,
+			1, NULL, HandleManagerBind);
+}

--- a/layer_shell.c
+++ b/layer_shell.c
@@ -1,0 +1,997 @@
+/* Wayland compositor running on top of an X server.
+
+Copyright (C) 2022 to various contributors.
+
+This file is part of 12to11.
+
+12to11 is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation, either version 3 of the License, or (at your
+option) any later version.
+
+12to11 is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with 12to11.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#include <string.h>
+
+#include <X11/extensions/XInput2.h>
+
+#include "compositor.h"
+#include "wlr-layer-shell-unstable-v1.h"
+
+#define LayerSurfaceFromRole(role) ((LayerSurface *) (role))
+
+#define DefaultEventMask					\
+  (ExposureMask | StructureNotifyMask | PropertyChangeMask)
+
+/* Anchor bits.  */
+enum
+  {
+    AnchorTop		= 1,
+    AnchorBottom	= 2,
+    AnchorLeft		= 4,
+    AnchorRight		= 8,
+  };
+
+/* Layer values.  */
+enum
+  {
+    LayerBackground	= 0,
+    LayerBottom		= 1,
+    LayerTop		= 2,
+    LayerOverlay	= 3,
+  };
+
+/* Keyboard interactivity.  */
+enum
+  {
+    KeyboardNone	= 0,
+    KeyboardExclusive	= 1,
+    KeyboardOnDemand	= 2,
+  };
+
+enum
+  {
+    IsMapped		= 1,
+    IsConfigured	= 1 << 1,
+    HasAck		= 1 << 2,
+    KeyboardGrabbed	= 1 << 3,
+    PendingBufferRelease = 1 << 4,
+    PendingFrameCallback = 1 << 5,
+  };
+
+typedef struct _LayerSurface LayerSurface;
+
+struct _LayerSurface
+{
+  /* The associated role.  */
+  Role role;
+
+  /* The subcompositor used to composite the surface.  */
+  Subcompositor *subcompositor;
+
+  /* The buffer release helper.  */
+  BufferReleaseHelper *release_helper;
+
+  /* The window and rendering target.  */
+  Window window;
+  RenderTarget target;
+
+  /* Reference count and flags.  */
+  int refcount, flags;
+
+  /* The output this surface is bound to, or NULL.  */
+  struct wl_resource *output_resource;
+
+  /* Double-buffered state.  Pending is applied at commit time.  */
+  uint32_t pending_anchor, current_anchor;
+  uint32_t pending_layer, current_layer;
+  uint32_t pending_keyboard, current_keyboard;
+  int pending_zone, current_zone;
+  int pending_margin_top, pending_margin_right;
+  int pending_margin_bottom, pending_margin_left;
+  int current_margin_top, current_margin_right;
+  int current_margin_bottom, current_margin_left;
+  int pending_width, pending_height;
+  int current_width, current_height;
+  uint32_t pending_edge, current_edge;
+
+  /* The size last sent in a configure event.  */
+  int configured_width, configured_height;
+
+  /* The geometry last applied to the window.  */
+  int win_x, win_y, win_w, win_h;
+
+  /* The layer whose EWMH hints were last applied.  */
+  uint32_t hinted_layer;
+
+  /* The pending configure serial.  */
+  uint32_t pending_serial;
+};
+
+/* The layer shell global.  */
+static struct wl_global *layer_shell_global;
+
+/* Association table of windows to layer surfaces, for X event
+   dispatch.  */
+static XLAssocTable *layer_surfaces;
+
+/* Forward declarations of static functions.  */
+
+static void ApplyState (LayerSurface *);
+static Bool GetOutputRect (LayerSurface *, int *, int *, int *, int *);
+static void ComputeGeometry (LayerSurface *, int, int, int, int,
+			     int *, int *, int *, int *);
+static void SendConfigure (LayerSurface *, int, int);
+static void SetEwmhHints (LayerSurface *);
+static void ApplyKeyboardInteractivity (LayerSurface *);
+static void DestroyBacking (LayerSurface *);
+static void RunFrameCallbacksConditionally (LayerSurface *);
+
+
+
+/* Geometry and state computation.  */
+
+static void
+ApplyState (LayerSurface *ls)
+{
+  ls->current_anchor = ls->pending_anchor;
+  ls->current_layer = ls->pending_layer;
+  ls->current_keyboard = ls->pending_keyboard;
+  ls->current_zone = ls->pending_zone;
+  ls->current_margin_top = ls->pending_margin_top;
+  ls->current_margin_right = ls->pending_margin_right;
+  ls->current_margin_bottom = ls->pending_margin_bottom;
+  ls->current_margin_left = ls->pending_margin_left;
+  ls->current_width = ls->pending_width;
+  ls->current_height = ls->pending_height;
+  ls->current_edge = ls->pending_edge;
+}
+
+static Bool
+GetOutputRect (LayerSurface *ls, int *ox, int *oy, int *ow, int *oh)
+{
+  if (XLGetOutputRectFromResource (ls->output_resource, ox, oy, ow, oh))
+    return True;
+
+  /* No specific output was given; fall back to the whole screen.  */
+  *ox = 0;
+  *oy = 0;
+  *ow = DisplayWidth (compositor.display,
+		      DefaultScreen (compositor.display));
+  *oh = DisplayHeight (compositor.display,
+		       DefaultScreen (compositor.display));
+  return True;
+}
+
+static void
+ComputeGeometry (LayerSurface *ls, int ox, int oy, int ow, int oh,
+		 int *x_out, int *y_out, int *w_out, int *h_out)
+{
+  Bool left, right, top, bottom;
+  int x, y, w, h;
+
+  left = ls->current_anchor & AnchorLeft;
+  right = ls->current_anchor & AnchorRight;
+  top = ls->current_anchor & AnchorTop;
+  bottom = ls->current_anchor & AnchorBottom;
+
+  /* Horizontal axis.  */
+  if (left && right)
+    {
+      w = ow - ls->current_margin_left - ls->current_margin_right;
+      x = ox + ls->current_margin_left;
+    }
+  else
+    {
+      w = ls->current_width ? ls->current_width : ow;
+
+      if (w < 1)
+	w = 1;
+
+      if (left)
+	x = ox + ls->current_margin_left;
+      else if (right)
+	x = ox + ow - w - ls->current_margin_right;
+      else
+	x = ox + (ow - w) / 2;
+    }
+
+  /* Vertical axis.  */
+  if (top && bottom)
+    {
+      h = oh - ls->current_margin_top - ls->current_margin_bottom;
+      y = oy + ls->current_margin_top;
+    }
+  else
+    {
+      h = ls->current_height ? ls->current_height : oh;
+
+      if (h < 1)
+	h = 1;
+
+      if (top)
+	y = oy + ls->current_margin_top;
+      else if (bottom)
+	y = oy + oh - h - ls->current_margin_bottom;
+      else
+	y = oy + (oh - h) / 2;
+    }
+
+  *x_out = x;
+  *y_out = y;
+  *w_out = w;
+  *h_out = h;
+}
+
+static void
+SendConfigure (LayerSurface *ls, int width, int height)
+{
+  ls->pending_serial = wl_display_next_serial (compositor.wl_display);
+
+  zwlr_layer_surface_v1_send_configure (ls->role.resource,
+					ls->pending_serial,
+					width, height);
+
+  ls->configured_width = width;
+  ls->configured_height = height;
+  ls->flags |= IsConfigured;
+}
+
+static void
+SetWindowType (LayerSurface *ls, Atom type_atom)
+{
+  XChangeProperty (compositor.display, ls->window,
+		   _NET_WM_WINDOW_TYPE, XA_ATOM, 32, PropModeReplace,
+		   (unsigned char *) &type_atom, 1);
+}
+
+static void
+SetWindowState (LayerSurface *ls, Atom *states, int nstates)
+{
+  XChangeProperty (compositor.display, ls->window,
+		   _NET_WM_STATE, XA_ATOM, 32, PropModeReplace,
+		   (unsigned char *) states, nstates);
+}
+
+static void
+SetEwmhHints (LayerSurface *ls)
+{
+  Atom states[4];
+  Atom type_atom;
+  int n;
+
+  switch (ls->current_layer)
+    {
+    case LayerBackground:
+      type_atom = _NET_WM_WINDOW_TYPE_DESKTOP;
+      states[0] = _NET_WM_STATE_BELOW;
+      break;
+
+    case LayerBottom:
+      type_atom = _NET_WM_WINDOW_TYPE_DOCK;
+      states[0] = _NET_WM_STATE_BELOW;
+      break;
+
+    case LayerTop:
+      type_atom = _NET_WM_WINDOW_TYPE_DOCK;
+      states[0] = _NET_WM_STATE_ABOVE;
+      break;
+
+    case LayerOverlay:
+    default:
+      type_atom = _NET_WM_WINDOW_TYPE_NOTIFICATION;
+      states[0] = _NET_WM_STATE_ABOVE;
+      break;
+    }
+
+  states[1] = _NET_WM_STATE_STICKY;
+  states[2] = _NET_WM_STATE_SKIP_TASKBAR;
+  states[3] = _NET_WM_STATE_SKIP_PAGER;
+  n = ArrayElements (states);
+
+  SetWindowType (ls, type_atom);
+  SetWindowState (ls, states, n);
+
+  ls->hinted_layer = ls->current_layer;
+}
+
+static void
+AcquireKeyboardGrab (LayerSurface *ls)
+{
+  XLList *tem;
+  Time time;
+  unsigned char mask_buf[XIMaskLen (XI_LASTEVENT)];
+  XIEventMask mask;
+
+  /* Use a freshly round-tripped server time, so the grab cannot fail
+     because of a stale timestamp.  */
+  time = XLGetServerTimeRoundtrip ();
+
+  mask.mask = mask_buf;
+  mask.mask_len = sizeof (mask_buf);
+  mask.deviceid = XIAllMasterDevices;
+
+  memset (mask_buf, 0, sizeof (mask_buf));
+  XISetMask (mask_buf, XI_FocusIn);
+  XISetMask (mask_buf, XI_FocusOut);
+  XISetMask (mask_buf, XI_KeyPress);
+  XISetMask (mask_buf, XI_KeyRelease);
+
+  for (tem = live_seats; tem; tem = tem->next)
+    {
+      Seat *seat;
+      int kbd;
+
+      seat = (Seat *) tem->data;
+      kbd = XLSeatGetKeyboardDevice (seat);
+
+      /* Grab the keyboard to the window, holding focus on it.  */
+      XIGrabDevice (compositor.display, kbd, ls->window,
+		    time, None, XIGrabModeAsync, XIGrabModeAsync,
+		    False, &mask);
+    }
+}
+
+static void
+ReleaseKeyboardGrab (LayerSurface *ls)
+{
+  XLList *tem;
+  Time time;
+
+  time = XLGetServerTimeRoundtrip ();
+
+  for (tem = live_seats; tem; tem = tem->next)
+    {
+      Seat *seat;
+
+      seat = (Seat *) tem->data;
+
+      XIUngrabDevice (compositor.display,
+		      XLSeatGetKeyboardDevice (seat), time);
+    }
+}
+
+static void
+ApplyKeyboardInteractivity (LayerSurface *ls)
+{
+  Bool desired;
+
+  if (!ls->role.surface)
+    return;
+
+  /* Override-redirect windows do not participate in window-manager
+     focus, so any keyboard interactivity requires a keyboard grab.
+     The pointer is left alone.  */
+  desired = ((ls->flags & IsMapped)
+	     && ls->current_keyboard != KeyboardNone);
+
+  if (desired && !(ls->flags & KeyboardGrabbed))
+    {
+      /* Make sure the window is actually viewable on the X server
+	 before grabbing.  */
+      XSync (compositor.display, False);
+
+      AcquireKeyboardGrab (ls);
+      ls->flags |= KeyboardGrabbed;
+    }
+  else if (!desired && (ls->flags & KeyboardGrabbed))
+    {
+      ReleaseKeyboardGrab (ls);
+      ls->flags &= ~KeyboardGrabbed;
+    }
+}
+
+
+/* Role callbacks.  */
+
+static void
+RunFrameCallbacks (LayerSurface *ls)
+{
+  struct timespec time;
+
+  if (!ls->role.surface)
+    return;
+
+  clock_gettime (CLOCK_MONOTONIC, &time);
+  XLSurfaceRunFrameCallbacks (ls->role.surface, time);
+
+  ls->flags &= ~PendingFrameCallback;
+}
+
+static void
+RunFrameCallbacksConditionally (LayerSurface *ls)
+{
+  if (!ls->role.surface)
+    return;
+
+  if (ls->flags & PendingBufferRelease)
+    /* Wait for all buffers to be released first.  */
+    ls->flags |= PendingFrameCallback;
+  else
+    RunFrameCallbacks (ls);
+}
+
+static void
+NoteFrame (FrameMode mode, uint64_t id, void *data,
+	   uint64_t msc, uint64_t ust)
+{
+  if (mode != ModeComplete && mode != ModePresented)
+    return;
+
+  /* Run frame callbacks, since a frame was just presented.  */
+  RunFrameCallbacksConditionally ((LayerSurface *) data);
+}
+
+static void
+AllBuffersReleased (void *data)
+{
+  LayerSurface *ls;
+
+  ls = data;
+
+  if (!ls->role.surface)
+    return;
+
+  ls->flags &= ~PendingBufferRelease;
+
+  /* Run pending frame callbacks.  */
+  if (ls->flags & PendingFrameCallback)
+    RunFrameCallbacks (ls);
+}
+
+static Window
+GetWindow (Surface *surface, Role *role)
+{
+  LayerSurface *ls;
+
+  ls = LayerSurfaceFromRole (role);
+  return ls->window;
+}
+
+static Bool
+Setup (Surface *surface, Role *role)
+{
+  LayerSurface *ls;
+
+  ls = LayerSurfaceFromRole (role);
+
+  role->surface = surface;
+
+  /* Prevent the surface from holding any other role.  */
+  surface->role_type = LayerType;
+
+  /* Attach the views to the subcompositor.  */
+  ViewSetSubcompositor (surface->view, ls->subcompositor);
+  ViewSetSubcompositor (surface->under, ls->subcompositor);
+
+  SubcompositorInsert (ls->subcompositor, surface->under);
+  SubcompositorInsert (ls->subcompositor, surface->view);
+
+  ls->refcount++;
+  return True;
+}
+
+static void
+Teardown (Surface *surface, Role *role)
+{
+  LayerSurface *ls;
+
+  role->surface = NULL;
+  ls = LayerSurfaceFromRole (role);
+
+  /* Release any keyboard grab held by this surface.  */
+  if (ls->flags & KeyboardGrabbed)
+    {
+      ReleaseKeyboardGrab (ls);
+      ls->flags &= ~KeyboardGrabbed;
+    }
+
+  ViewUnparent (surface->view);
+  ViewUnparent (surface->under);
+
+  ViewSetSubcompositor (surface->view, NULL);
+  ViewSetSubcompositor (surface->under, NULL);
+
+  DestroyBacking (ls);
+}
+
+static void
+Commit (Surface *surface, Role *role)
+{
+  LayerSurface *ls;
+  int ox, oy, ow, oh, x, y, w, h;
+  struct timespec time;
+
+  ls = LayerSurfaceFromRole (role);
+
+  if (!ls->role.resource)
+    return;
+
+  /* Apply double-buffered state.  */
+  ApplyState (ls);
+
+  /* Update EWMH hints if the layer changed.  */
+  if (ls->hinted_layer != ls->current_layer)
+    SetEwmhHints (ls);
+
+  /* Compute the desired geometry.  */
+  GetOutputRect (ls, &ox, &oy, &ow, &oh);
+  ComputeGeometry (ls, ox, oy, ow, oh, &x, &y, &w, &h);
+
+  /* Send a configure event if the size has changed or no configure
+     has yet been sent.  */
+  if (!(ls->flags & IsConfigured)
+      || w != ls->configured_width
+      || h != ls->configured_height)
+    SendConfigure (ls, w, h);
+
+  /* Map or unmap the surface depending on whether a buffer has been
+     attached and a configure has been acknowledged.  */
+  if (surface->current_state.buffer && (ls->flags & HasAck))
+    {
+      /* Apply the new geometry if it changed.  */
+      if (x != ls->win_x || y != ls->win_y
+	  || w != ls->win_w || h != ls->win_h)
+	{
+	  XMoveResizeWindow (compositor.display, ls->window, x, y, w, h);
+	  ls->win_x = x;
+	  ls->win_y = y;
+	  ls->win_w = w;
+	  ls->win_h = h;
+	}
+
+      if (!(ls->flags & IsMapped))
+	{
+	  XMapRaised (compositor.display, ls->window);
+	  ls->flags |= IsMapped;
+	}
+
+      SubcompositorUpdate (ls->subcompositor);
+    }
+  else
+    {
+      if (ls->flags & IsMapped)
+	{
+	  XUnmapWindow (compositor.display, ls->window);
+	  ls->flags &= ~IsMapped;
+	}
+
+      /* Run frame callbacks even when unmapping.  */
+      clock_gettime (CLOCK_MONOTONIC, &time);
+      XLSurfaceRunFrameCallbacks (surface, time);
+    }
+
+  /* Apply or release the keyboard grab as appropriate.  */
+  ApplyKeyboardInteractivity (ls);
+}
+
+static void
+ReleaseBuffer (Surface *surface, Role *role, ExtBuffer *buffer)
+{
+  LayerSurface *ls;
+  RenderBuffer render_buffer;
+
+  ls = LayerSurfaceFromRole (role);
+  render_buffer = XLRenderBufferFromBuffer (buffer);
+
+  if (RenderIsBufferIdle (render_buffer, ls->target))
+    XLReleaseBuffer (buffer);
+  else
+    {
+      /* Release the buffer once it becomes idle, or is destroyed.  */
+      ReleaseBufferWithHelper (ls->release_helper, buffer, ls->target);
+
+      /* Defer frame callbacks until the buffer is released.  */
+      ls->flags |= PendingBufferRelease;
+    }
+}
+
+static void
+SubsurfaceUpdate (Surface *surface, Role *role)
+{
+  LayerSurface *ls;
+
+  ls = LayerSurfaceFromRole (role);
+  SubcompositorUpdate (ls->subcompositor);
+}
+
+static void
+DestroyBacking (LayerSurface *ls)
+{
+  if (--ls->refcount)
+    return;
+
+  RenderDestroyRenderTarget (ls->target);
+  XDestroyWindow (compositor.display, ls->window);
+  FreeBufferReleaseHelper (ls->release_helper);
+
+  if (layer_surfaces)
+    XLDeleteAssoc (layer_surfaces, ls->window);
+
+  SubcompositorFree (ls->subcompositor);
+  XLFree (ls);
+}
+
+
+/* Layer surface resource requests.  */
+
+static void
+DestroyLayerSurface (struct wl_client *client, struct wl_resource *resource)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+
+  if (ls->role.surface)
+    XLSurfaceReleaseRole (ls->role.surface, &ls->role);
+
+  wl_resource_destroy (resource);
+}
+
+static void
+SetSize (struct wl_client *client, struct wl_resource *resource,
+	 uint32_t width, uint32_t height)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_width = width;
+  ls->pending_height = height;
+}
+
+static void
+SetAnchor (struct wl_client *client, struct wl_resource *resource,
+	   uint32_t anchor)
+{
+  LayerSurface *ls;
+
+  if (anchor > (AnchorTop | AnchorBottom | AnchorLeft | AnchorRight))
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_ANCHOR,
+			      "invalid anchor bitfield");
+      return;
+    }
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_anchor = anchor;
+}
+
+static void
+SetExclusiveZone (struct wl_client *client, struct wl_resource *resource,
+		  int32_t zone)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_zone = zone;
+}
+
+static void
+SetMargin (struct wl_client *client, struct wl_resource *resource,
+	   int32_t top, int32_t right, int32_t bottom, int32_t left)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_margin_top = top;
+  ls->pending_margin_right = right;
+  ls->pending_margin_bottom = bottom;
+  ls->pending_margin_left = left;
+}
+
+static void
+SetKeyboardInteractivity (struct wl_client *client,
+			  struct wl_resource *resource,
+			  uint32_t keyboard_interactivity)
+{
+  LayerSurface *ls;
+
+  if (keyboard_interactivity > KeyboardOnDemand)
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_KEYBOARD_INTERACTIVITY,
+			      "invalid keyboard interactivity");
+      return;
+    }
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_keyboard = keyboard_interactivity;
+}
+
+static void
+GetPopup (struct wl_client *client, struct wl_resource *resource,
+	  struct wl_resource *popup_resource)
+{
+  /* Popup positioning relative to a layer surface is not implemented;
+     layer surfaces are generally full-output overlays.  */
+}
+
+static void
+AckConfigure (struct wl_client *client, struct wl_resource *resource,
+	      uint32_t serial)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+
+  /* Allow mapping once the client has acknowledged a configure.  */
+  ls->flags |= HasAck;
+}
+
+static void
+SetLayer (struct wl_client *client, struct wl_resource *resource,
+	  uint32_t layer)
+{
+  LayerSurface *ls;
+
+  if (layer > LayerOverlay)
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER,
+			      "invalid layer");
+      return;
+    }
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_layer = layer;
+}
+
+static void
+SetExclusiveEdge (struct wl_client *client, struct wl_resource *resource,
+		  uint32_t edge)
+{
+  LayerSurface *ls;
+
+  if (edge > (AnchorTop | AnchorBottom | AnchorLeft | AnchorRight))
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_EXCLUSIVE_EDGE,
+			      "invalid exclusive edge");
+      return;
+    }
+
+  ls = wl_resource_get_user_data (resource);
+  ls->pending_edge = edge;
+}
+
+static const struct zwlr_layer_surface_v1_interface layer_surface_impl =
+  {
+    .set_size = SetSize,
+    .set_anchor = SetAnchor,
+    .set_exclusive_zone = SetExclusiveZone,
+    .set_margin = SetMargin,
+    .set_keyboard_interactivity = SetKeyboardInteractivity,
+    .get_popup = GetPopup,
+    .ack_configure = AckConfigure,
+    .destroy = DestroyLayerSurface,
+    .set_layer = SetLayer,
+    .set_exclusive_edge = SetExclusiveEdge,
+  };
+
+static void
+HandleLayerSurfaceResourceDestroy (struct wl_resource *resource)
+{
+  LayerSurface *ls;
+
+  ls = wl_resource_get_user_data (resource);
+  ls->role.resource = NULL;
+  DestroyBacking (ls);
+}
+
+static void
+GetLayerSurface (struct wl_client *client, struct wl_resource *resource,
+		 uint32_t id, struct wl_resource *surface_resource,
+		 struct wl_resource *output_resource, uint32_t layer,
+		 const char *name)
+{
+  Surface *surface;
+  LayerSurface *ls;
+  XSetWindowAttributes attrs;
+  unsigned long flags;
+
+  surface = wl_resource_get_user_data (surface_resource);
+
+  if (layer > LayerOverlay)
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER,
+			      "invalid layer value");
+      return;
+    }
+
+  if (surface->role_type != AnythingType
+      && surface->role_type != LayerType)
+    {
+      wl_resource_post_error (resource, ZWLR_LAYER_SHELL_V1_ERROR_ROLE,
+			      "a role is/was already present on the"
+			      " given surface");
+      return;
+    }
+
+  if (surface->current_state.buffer)
+    {
+      wl_resource_post_error (resource,
+			      ZWLR_LAYER_SHELL_V1_ERROR_ALREADY_CONSTRUCTED,
+			      "surface already has a buffer attached or"
+			      " committed");
+      return;
+    }
+
+  ls = XLSafeMalloc (sizeof *ls);
+
+  if (!ls)
+    {
+      wl_resource_post_no_memory (resource);
+      return;
+    }
+
+  memset (ls, 0, sizeof *ls);
+
+  ls->role.resource
+    = wl_resource_create (client, &zwlr_layer_surface_v1_interface,
+			  wl_resource_get_version (resource), id);
+
+  if (!ls->role.resource)
+    {
+      wl_resource_post_no_memory (resource);
+      XLFree (ls);
+      return;
+    }
+
+  ls->pending_layer = layer;
+  ls->current_layer = layer;
+  ls->output_resource = output_resource;
+
+  /* Create the override-redirect window.  */
+  attrs.colormap = compositor.colormap;
+  attrs.border_pixel = border_pixel;
+  attrs.event_mask = DefaultEventMask;
+  attrs.cursor = InitDefaultCursor ();
+  attrs.override_redirect = True;
+  flags = (CWColormap | CWBorderPixel | CWEventMask
+	   | CWCursor | CWOverrideRedirect);
+
+  ls->window = XCreateWindow (compositor.display,
+			      DefaultRootWindow (compositor.display),
+			      0, 0, 20, 20, 0, compositor.n_planes,
+			      InputOutput, compositor.visual, flags,
+			      &attrs);
+
+  /* Select input events so that pointer and keyboard events are
+     delivered to this window and routed to the surface.  */
+  XLSelectStandardEvents (ls->window);
+
+  ls->subcompositor = MakeSubcompositor ();
+  ls->target = RenderTargetFromWindow (ls->window, DefaultEventMask);
+  RenderSetClient (ls->target, client);
+
+  ls->release_helper = MakeBufferReleaseHelper (AllBuffersReleased, ls);
+
+  SubcompositorSetTarget (ls->subcompositor, &ls->target);
+
+  /* Run frame callbacks whenever a frame is presented, so that the
+     client can keep updating its contents (e.g. a region-selection
+     rectangle).  */
+  SubcompositorSetNoteFrameCallback (ls->subcompositor, NoteFrame, ls);
+
+  /* Apply the initial EWMH hints for this layer.  */
+  SetEwmhHints (ls);
+
+  /* Create the association table if necessary.  */
+  if (!layer_surfaces)
+    layer_surfaces = XLCreateAssocTable (16);
+
+  XLMakeAssoc (layer_surfaces, ls->window, ls);
+
+  /* Fill in the role function table.  */
+  ls->role.funcs.setup = Setup;
+  ls->role.funcs.teardown = Teardown;
+  ls->role.funcs.commit = Commit;
+  ls->role.funcs.release_buffer = ReleaseBuffer;
+  ls->role.funcs.subsurface_update = SubsurfaceUpdate;
+  ls->role.funcs.get_window = GetWindow;
+
+  wl_resource_set_implementation (ls->role.resource,
+				  &layer_surface_impl, ls,
+				  HandleLayerSurfaceResourceDestroy);
+  ls->refcount++;
+
+  if (!XLSurfaceAttachRole (surface, &ls->role))
+    abort ();
+}
+
+static void
+DestroyShell (struct wl_client *client, struct wl_resource *resource)
+{
+  wl_resource_destroy (resource);
+}
+
+static const struct zwlr_layer_shell_v1_interface layer_shell_impl =
+  {
+    .get_layer_surface = GetLayerSurface,
+    .destroy = DestroyShell,
+  };
+
+static void
+HandleBind (struct wl_client *client, void *data,
+	    uint32_t version, uint32_t id)
+{
+  struct wl_resource *resource;
+
+  resource = wl_resource_create (client, &zwlr_layer_shell_v1_interface,
+				 version, id);
+
+  if (!resource)
+    {
+      wl_client_post_no_memory (client);
+      return;
+    }
+
+  wl_resource_set_implementation (resource, &layer_shell_impl,
+				  NULL, NULL);
+}
+
+void
+XLInitLayerShell (void)
+{
+  layer_shell_global
+    = wl_global_create (compositor.wl_display,
+			&zwlr_layer_shell_v1_interface,
+			4, NULL, HandleBind);
+}
+
+
+/* X event dispatch.  */
+
+Bool
+XLHandleOneXEventForLayerShell (XEvent *event)
+{
+  LayerSurface *ls;
+  Window window;
+
+  if (!layer_surfaces)
+    return False;
+
+  window = None;
+
+  if (event->type == Expose)
+    window = event->xexpose.window;
+  else if (event->type == GenericEvent
+	   && event->xgeneric.extension == xi2_opcode)
+    /* Determine the window this input event is directed at.  */
+    window = XLGetGEWindowForSeats (event);
+
+  if (window == None)
+    return False;
+
+  ls = XLLookUpAssoc (layer_surfaces, window);
+
+  if (!ls)
+    return False;
+
+  if (event->type == Expose)
+    {
+      SubcompositorExpose (ls->subcompositor, event);
+      return True;
+    }
+
+  if (event->type == GenericEvent)
+    {
+      /* Route pointer and keyboard events to the surface owning this
+	 window, just as is done for xdg surfaces.  */
+      if (ls->role.surface)
+	XLDispatchGEForSeats (event, ls->role.surface,
+			      ls->subcompositor);
+
+      return True;
+    }
+
+  return False;
+}

--- a/output.c
+++ b/output.c
@@ -956,6 +956,36 @@ XLGetOutputRectAt (int x, int y, int *x_out, int *y_out,
 }
 
 Bool
+XLGetOutputRectFromResource (struct wl_resource *resource, int *x_out,
+			     int *y_out, int *width_out, int *height_out)
+{
+  Output *output;
+
+  /* NULL resource means the client did not specify an output.  */
+  if (!resource)
+    return False;
+
+  output = wl_resource_get_user_data (resource);
+
+  if (!output)
+    return False;
+
+  if (x_out)
+    *x_out = output->x;
+
+  if (y_out)
+    *y_out = output->y;
+
+  if (width_out)
+    *width_out = output->width;
+
+  if (height_out)
+    *height_out = output->height;
+
+  return True;
+}
+
+Bool
 XLHandleOneXEventForOutputs (XEvent *event)
 {
   XRRNotifyEvent *notify;

--- a/run.c
+++ b/run.c
@@ -168,6 +168,9 @@ HandleOneXEvent (XEvent *event)
 
   if (XLHandleOneXEventForTest (event))
     return;
+
+  if (XLHandleOneXEventForLayerShell (event))
+    return;
 }
 
 static void

--- a/shm.c
+++ b/shm.c
@@ -22,6 +22,7 @@ along with 12to11.  If not, see <https://www.gnu.org/licenses/>.  */
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <sys/mman.h>
 
@@ -63,6 +64,10 @@ typedef struct _Buffer
 
   /* The width and height of this buffer.  */
   unsigned int width, height;
+
+  /* The format, offset and stride of this buffer, for readback.  */
+  uint32_t format;
+  int offset, stride;
 
   /* The wl_resource corresponding to this buffer.  */
   struct wl_resource *resource;
@@ -308,6 +313,9 @@ CreateBuffer (struct wl_client *client, struct wl_resource *resource,
   buffer->render_buffer = render_buffer;
   buffer->width = width;
   buffer->height = height;
+  buffer->format = format;
+  buffer->offset = offset;
+  buffer->stride = stride;
   buffer->pool = pool;
   buffer->refcount = 1;
 
@@ -582,4 +590,54 @@ XLInitShm (void)
   global_shm = wl_global_create (compositor.wl_display,
 				 &wl_shm_interface, 1,
 				 NULL, HandleBind);
+}
+
+/* Describe the shared memory backing of an ExtBuffer.  Returns True if
+   the buffer is backed by shared memory, in which case the out
+   parameters are filled in.  FD is duplicated and must be closed by
+   the caller.  */
+
+Bool
+XLShmBufferDescribe (ExtBuffer *buffer, int *fd, size_t *pool_size,
+		     uint32_t *format, int *offset, int *stride,
+		     unsigned int *width, unsigned int *height)
+{
+  Buffer *b;
+
+  /* Verify that this buffer really is a shared memory buffer by
+     comparing its dereference function pointer with the shared memory
+     dereference function.  */
+
+  if (buffer->funcs.dereference != DereferenceBufferFunc)
+    return False;
+
+  b = (Buffer *) buffer;
+
+  if (fd)
+    {
+      *fd = dup (b->pool->fd);
+
+      if (*fd < 0)
+	return False;
+    }
+
+  if (pool_size)
+    *pool_size = b->pool->size;
+
+  if (format)
+    *format = b->format;
+
+  if (offset)
+    *offset = b->offset;
+
+  if (stride)
+    *stride = b->stride;
+
+  if (width)
+    *width = b->width;
+
+  if (height)
+    *height = b->height;
+
+  return True;
 }

--- a/wlr-layer-shell-unstable-v1.xml
+++ b/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,407 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="5">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="5">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
+      <entry name="invalid_exclusive_edge" value="4" summary="exclusive edge is invalid given the surface anchors"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
+
+    <!-- Version 5 additions -->
+
+    <request name="set_exclusive_edge" since="5">
+      <description summary="set the edge the exclusive zone will be applied to">
+        Requests an edge for the exclusive zone to apply. The exclusive
+        edge will be automatically deduced from anchor points when possible,
+        but when the surface is anchored to a corner, it will be necessary
+        to set it explicitly to disambiguate, as it is not possible to deduce
+        which one of the two corner edges should be used.
+
+        The edge must be one the surface is anchored to, otherwise the
+        invalid_exclusive_edge protocol error will be raised.
+      </description>
+      <arg name="edge" type="uint" enum="anchor"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
This allows `xfce4-screenshooter` to take a screenshots of the x11 desktop while using the wayland backend. 
